### PR TITLE
refactor(collection-mapper): make the mapping more consistent

### DIFF
--- a/src/decorator/decorators.spec.ts
+++ b/src/decorator/decorators.spec.ts
@@ -111,7 +111,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop!.key!.uuid).toBeFalsy()
         expect(prop!.transient).toBeFalsy()
         expect(prop!.typeInfo).toBeDefined()
-        expect(prop!.typeInfo!.isCustom).toBeFalsy()
         expect(prop!.typeInfo!.type).toBe(String)
       })
 
@@ -125,7 +124,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop!.key!.uuid).toBeFalsy()
         expect(prop!.transient).toBeFalsy()
         expect(prop!.typeInfo).toBeDefined()
-        expect(prop!.typeInfo!.isCustom).toBeTruthy()
       })
 
       it('active', () => {
@@ -136,7 +134,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop.key).toBeUndefined()
         expect(prop.transient).toBeFalsy()
         expect(prop.typeInfo).toBeDefined()
-        expect(prop.typeInfo.isCustom).toBeFalsy()
         expect(prop.typeInfo.type).toBe(Boolean)
       })
 
@@ -148,7 +145,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop.key).toBeUndefined()
         expect(prop.transient).toBeFalsy()
         expect(prop.typeInfo).toBeDefined()
-        expect(prop.typeInfo.isCustom).toBeTruthy()
         expect(prop.typeInfo.type).toBe(Set)
       })
 
@@ -161,7 +157,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop.transient).toBeFalsy()
         expect(prop.isSortedCollection).toBeTruthy()
         expect(prop.typeInfo).toBeDefined()
-        expect(prop.typeInfo.isCustom).toBeTruthy()
         expect(prop.typeInfo.type).toBe(Set)
       })
 
@@ -175,7 +170,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop.isSortedCollection).toBeTruthy()
 
         expect(prop.typeInfo).toBeDefined()
-        expect(prop.typeInfo.isCustom).toBeTruthy()
         expect(prop.typeInfo.type).toBe(Set)
 
         expect(prop.typeInfo.genericType).toBeDefined()
@@ -190,7 +184,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop.key).toBeUndefined()
         expect(prop.transient).toBeFalsy()
         expect(prop.typeInfo).toBeDefined()
-        expect(prop.typeInfo.isCustom).toBeTruthy()
         expect(prop.typeInfo.type).toBe(Map)
       })
 
@@ -202,7 +195,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop.key).toBeUndefined()
         expect(prop.transient).toBeTruthy()
         expect(prop.typeInfo).toBeDefined()
-        expect(prop.typeInfo.isCustom).toBeFalsy()
         expect(prop.typeInfo.type).toBe(String)
       })
 
@@ -219,7 +211,6 @@ describe('Decorators should add correct metadata', () => {
         expect(prop.key).toBeUndefined()
         expect(prop.transient).toBeFalsy()
         expect(prop.typeInfo).toBeDefined()
-        expect(prop.typeInfo.isCustom).toBeTruthy()
         expect(prop.typeInfo.type).toBe(NestedObject)
       })
     })
@@ -328,11 +319,11 @@ describe('Decorators should add correct metadata', () => {
     it('should add enum type to property', () => {
       const enumPropertyMetadata = metadata.forProperty('type')!
       expect(enumPropertyMetadata.typeInfo).toBeDefined()
-      expect(enumPropertyMetadata.typeInfo).toEqual({ type: Number, isCustom: false })
+      expect(enumPropertyMetadata.typeInfo).toEqual({ type: Number })
 
       const strEnumPropertyMetadata = metadata.forProperty('strType')!
       expect(strEnumPropertyMetadata.typeInfo).toBeDefined()
-      expect(strEnumPropertyMetadata.typeInfo).toEqual({ type: String, isCustom: false })
+      expect(strEnumPropertyMetadata.typeInfo).toEqual({ type: String })
     })
   })
 

--- a/src/decorator/decorators.spec.ts
+++ b/src/decorator/decorators.spec.ts
@@ -19,7 +19,8 @@ import {
   SimpleModel,
 } from '../../test/models'
 import { Form } from '../../test/models/real-world'
-import { GSIPartitionKey, GSISortKey, LSISortKey, PartitionKey, Property, SortedSet, SortKey, Transient } from './impl'
+import { GSIPartitionKey, GSISortKey, LSISortKey, PartitionKey, Property, SortKey, Transient } from './impl'
+import { CollectionProperty } from './impl/collection/collection-property.decorator'
 import { Model } from './impl/model/model.decorator'
 import { Metadata, metadataForClass, metadataForModel, ModelMetadata } from './index'
 import { metadataForProperty } from './metadata'
@@ -370,7 +371,7 @@ describe('Decorators should add correct metadata', () => {
 
       @Model()
       class B extends A {
-        @SortedSet()
+        @CollectionProperty({ sorted: true })
         myOwnProp: string[]
       }
 

--- a/src/decorator/impl/collection/collection-property-data.model.ts
+++ b/src/decorator/impl/collection/collection-property-data.model.ts
@@ -1,0 +1,29 @@
+import { BinaryAttribute, MapperForType, NumberAttribute, StringAttribute } from '../../../mapper'
+import { ModelConstructor } from '../../../model'
+
+export interface CollectionPropertyDataBase<R, T extends StringAttribute | NumberAttribute | BinaryAttribute> {
+  /**
+   * the name of property how it is named in dynamoDB
+   */
+  name?: string
+
+  /**
+   * if the collection should preserve the order. if so it will be stored as (L)ist
+   */
+  sorted?: boolean
+
+  /**
+   * provide an itemMapper if you want your complex items being mapped to String|Number|Binary attribute
+   * (e.g. because you can't store it in a (S)et otherwise)
+   * only provide either itemMapper or itemType --> not both
+   * itemMapper is basically intended to be used with [S]et. though it also works with [L]ist
+   */
+  itemMapper?: MapperForType<R, T>
+
+  /**
+   * provide an itemType (class with @Model decorator) for complex types (eg. Set<ComplexType>)
+   * collections with complex types will be stored as (L)ist
+   * only provide either itemType or itemMapper --> not both
+   */
+  itemType?: ModelConstructor<any>
+}

--- a/src/decorator/impl/collection/collection-property.decorator.ts
+++ b/src/decorator/impl/collection/collection-property.decorator.ts
@@ -1,0 +1,65 @@
+import { BinaryAttribute, MapperForType, NumberAttribute, StringAttribute } from '../../../mapper'
+import {
+  wrapMapperForDynamoListJsArray,
+  wrapMapperForDynamoListJsSet,
+  wrapMapperForDynamoSetJsArray,
+  wrapMapperForDynamoSetJsSet,
+} from '../../../mapper/wrap-mapper-for-collection.function'
+import { ModelConstructor } from '../../../model'
+import { PropertyMetadata, TypeInfo } from '../../metadata'
+import { getMetadataType } from '../../util'
+import { initOrUpdateProperty } from '../property/init-or-update-property.function'
+import { CollectionPropertyDataBase } from './collection-property-data.model'
+
+type DecoratorFn = (target: object, propertyKey: string | symbol) => void
+
+export function CollectionProperty<R, T extends StringAttribute | NumberAttribute | BinaryAttribute>(opts: CollectionPropertyDataBase<R, T> = {}): DecoratorFn {
+  return (target: object, propertyKey: string | symbol) => {
+    if (typeof propertyKey === 'string') {
+
+      const type: ModelConstructor<any> = getMetadataType(target, propertyKey)
+
+      if (type !== Set && type !== Array) {
+        throw new Error(`[${target.constructor.name}::${propertyKey}] The CollectionProperty decorator is meant for properties of type Set or Array`)
+      }
+
+      const meta: Partial<PropertyMetadata<any>> & { typeInfo: TypeInfo } = {
+        name: propertyKey,
+        nameDb: opts && opts.name || propertyKey,
+        typeInfo: {
+          type,
+          isCustom: true,
+        },
+        isSortedCollection: !!opts.sorted,
+      }
+
+      const hasItemType = 'itemType' in opts && !!opts.itemType
+      const hasItemMapper = 'itemMapper' in opts && !!opts.itemMapper
+
+      if (hasItemMapper && hasItemType) {
+        throw new Error(`[${target.constructor.name}::${propertyKey}] provide either itemType or itemMapper, not both`)
+      }
+
+      if (hasItemType) {
+        meta.typeInfo.genericType = opts.itemType
+      }
+
+      if (hasItemMapper) {
+        const itemMapper = <MapperForType<any, any>>opts.itemMapper
+
+        const wrappedMapper: MapperForType<any, any> = type === Array
+          ? !!opts.sorted
+            ? wrapMapperForDynamoListJsArray(itemMapper)
+            : wrapMapperForDynamoSetJsArray(itemMapper)
+          : !!opts.sorted
+            ? wrapMapperForDynamoListJsSet(itemMapper)
+            : wrapMapperForDynamoSetJsSet(itemMapper)
+
+        meta.mapper = () => wrappedMapper
+        meta.mapperForSingleItem = () => itemMapper
+      }
+
+      initOrUpdateProperty(meta, target, propertyKey)
+    }
+  }
+}

--- a/src/decorator/impl/collection/collection-property.decorator.ts
+++ b/src/decorator/impl/collection/collection-property.decorator.ts
@@ -26,10 +26,7 @@ export function CollectionProperty<R, T extends StringAttribute | NumberAttribut
       const meta: Partial<PropertyMetadata<any>> & { typeInfo: TypeInfo } = {
         name: propertyKey,
         nameDb: opts && opts.name || propertyKey,
-        typeInfo: {
-          type,
-          isCustom: true,
-        },
+        typeInfo: {type},
         isSortedCollection: !!opts.sorted,
       }
 

--- a/src/decorator/impl/collection/sorted-set.decorator.ts
+++ b/src/decorator/impl/collection/sorted-set.decorator.ts
@@ -12,8 +12,7 @@ export function SortedSet(modelConstructor?: ModelConstructor<any>): PropertyDec
   return (target: any, propertyKey: string | symbol) => {
     if (typeof propertyKey === 'string') {
       const typeInfo: TypeInfo = {
-        type: Set,
-        isCustom: true,
+        type: Set
       }
 
       if (modelConstructor) {

--- a/src/decorator/impl/collection/sorted-set.decorator.ts
+++ b/src/decorator/impl/collection/sorted-set.decorator.ts
@@ -6,6 +6,7 @@ import { initOrUpdateProperty } from '../property/init-or-update-property.functi
  * Only the L(ist) dynamo datatype preservers the order of inserted items, so we have to make sure the L(ist) type is used
  * when persisting. The modelConstructor is required if the collection items
  * have some property decorators, so we can retrieve this information using the model class.
+ * @deprecated instead use @CollectionProperty({ sorted: true, itemType?: ModelConstructor })
  */
 export function SortedSet(modelConstructor?: ModelConstructor<any>): PropertyDecorator {
   return (target: any, propertyKey: string | symbol) => {

--- a/src/decorator/impl/collection/typed-array.decorator.ts
+++ b/src/decorator/impl/collection/typed-array.decorator.ts
@@ -5,6 +5,7 @@ import { initOrUpdateProperty } from '../property/init-or-update-property.functi
 /**
  * Makes sure the property will be mapped to a L(ist) type. The modelConstructor is required if the collection items
  * have some property decorators, so we can retrieve this information using the model class.
+ * @deprecated instead use @CollectionProperty({ itemType?: ModelConstructor })
  */
 export function TypedArray<T>(modelConstructor?: ModelConstructor<T>): PropertyDecorator {
   return (target: object, propertyKey: string | symbol) => {

--- a/src/decorator/impl/collection/typed-array.decorator.ts
+++ b/src/decorator/impl/collection/typed-array.decorator.ts
@@ -10,10 +10,7 @@ import { initOrUpdateProperty } from '../property/init-or-update-property.functi
 export function TypedArray<T>(modelConstructor?: ModelConstructor<T>): PropertyDecorator {
   return (target: object, propertyKey: string | symbol) => {
     if (typeof propertyKey === 'string') {
-      const typeInfo: TypeInfo = {
-        type: Array,
-        isCustom: true,
-      }
+      const typeInfo: TypeInfo = {type: Array}
 
       if (modelConstructor) {
         typeInfo.genericType = modelConstructor

--- a/src/decorator/impl/collection/typed-set.decorator.ts
+++ b/src/decorator/impl/collection/typed-set.decorator.ts
@@ -5,6 +5,7 @@ import { initOrUpdateProperty } from '../property/init-or-update-property.functi
 /**
  * Makes sure the property will be marshalled to a S(et) type. The modelConstructor is required if the collection items
  * have some property decorators, so we can retrieve this information using the model class.
+ * @deprecated instead use @CollectionProperty({ itemType?: modelConstructor })
  */
 export function TypedSet(modelConstructor?: ModelConstructor<any>): PropertyDecorator {
   return (target: any, propertyKey: string | symbol) => {

--- a/src/decorator/impl/collection/typed-set.decorator.ts
+++ b/src/decorator/impl/collection/typed-set.decorator.ts
@@ -11,8 +11,7 @@ export function TypedSet(modelConstructor?: ModelConstructor<any>): PropertyDeco
   return (target: any, propertyKey: string | symbol) => {
     if (typeof propertyKey === 'string') {
       const typeInfo: TypeInfo = {
-        type: Set,
-        isCustom: true,
+        type: Set
       }
 
       if (modelConstructor) {

--- a/src/decorator/impl/custom-mapper/custom-mapper.decorator.ts
+++ b/src/decorator/impl/custom-mapper/custom-mapper.decorator.ts
@@ -1,6 +1,11 @@
 import { MapperForType } from '../../../mapper'
 import { initOrUpdateProperty } from '../property/init-or-update-property.function'
 
+/**
+ *
+ * @param customMapper
+ * @deprecated use @Property({mapper: YourCustomMapper}) instead
+ */
 export function CustomMapper(customMapper: MapperForType<any, any>): PropertyDecorator {
   return (target: any, propertyKey: string | symbol) => {
     if (typeof propertyKey === 'string') {

--- a/src/decorator/impl/property/init-or-update-property.function.ts
+++ b/src/decorator/impl/property/init-or-update-property.function.ts
@@ -1,4 +1,3 @@
-import { AttributeValueType } from '../../../mapper/type/attribute-value-type.type'
 import { Attribute } from '../../../mapper/type/attribute.type'
 import { ModelConstructor } from '../../../model/model-constructor'
 import { PropertyMetadata, TypeInfo } from '../../metadata/property-metadata.model'
@@ -35,12 +34,7 @@ function createNewProperty(
   propertyKey: string,
 ): PropertyMetadata<any> {
   const propertyType: ModelConstructor<any> = getMetadataType(target, propertyKey)
-  const isCustom = isCustomType(propertyType)
-
-  const typeInfo: TypeInfo = {
-    type: propertyType,
-    isCustom,
-  }
+  const typeInfo: TypeInfo = { type: propertyType}
 
   propertyOptions = {
     name: propertyKey,
@@ -50,12 +44,4 @@ function createNewProperty(
   }
 
   return <PropertyMetadata<any>>propertyOptions
-}
-
-/**
- * TODO LOW:BINARY make sure to implement the context dependant details of Binary (Buffer vs. Uint8Array)
- * @returns {boolean} true if the type cannot be mapped by dynamo document client
- */
-function isCustomType(type: AttributeValueType): boolean {
-  return <any>type !== String && <any>type !== Number && <any>type !== Boolean && <any>type !== Uint8Array
 }

--- a/src/decorator/impl/property/property-data.model.ts
+++ b/src/decorator/impl/property/property-data.model.ts
@@ -1,4 +1,7 @@
+import { MapperForType } from '../../../mapper'
+
 export interface PropertyData {
   // the name of property how it is named in dynamoDB
   name: string
+  mapper: MapperForType<any, any>
 }

--- a/src/decorator/impl/property/property.decorator.ts
+++ b/src/decorator/impl/property/property.decorator.ts
@@ -9,6 +9,12 @@ export function Property(opts: Partial<PropertyData> = {}): PropertyDecorator {
         name: propertyKey,
         nameDb: opts.name || propertyKey,
       }
+
+      if ('mapper' in opts && !!opts.mapper) {
+        const m = opts.mapper
+        propertyOptions.mapper = () => m
+      }
+
       initOrUpdateProperty(propertyOptions, target, propertyKey)
     }
   }

--- a/src/decorator/metadata/metadata.spec.ts
+++ b/src/decorator/metadata/metadata.spec.ts
@@ -33,7 +33,6 @@ describe('metadata', () => {
     expect(forId!.key).toBeDefined()
     expect(forId!.name).toBe('id')
     expect(forId!.typeInfo).toBeDefined()
-    expect(forId!.typeInfo!.isCustom).toBeFalsy()
   })
 
   it('getKeysWithUUID', () => {

--- a/src/decorator/metadata/property-metadata.model.ts
+++ b/src/decorator/metadata/property-metadata.model.ts
@@ -6,8 +6,6 @@ import { ModelConstructor } from '../../model/model-constructor'
 
 export interface TypeInfo {
   type: ModelConstructor<any>
-  // true if we use a non native type for dynamo document client
-  isCustom?: boolean
   genericType?: ModelConstructor<any>
 }
 
@@ -55,6 +53,12 @@ export function hasGenericType(
   propertyMetadata?: PropertyMetadata<any, any>,
 ): propertyMetadata is PropertyMetadata<any, any> & { typeInfo: { genericType: ModelConstructor<any> } } {
   return !!(propertyMetadata && propertyMetadata.typeInfo && propertyMetadata.typeInfo.genericType)
+}
+
+export function hasType(
+  propertyMetadata?: PropertyMetadata<any, any>,
+): propertyMetadata is PropertyMetadata<any, any> & { typeInfo: { type: ModelConstructor<any> } } {
+  return !!(propertyMetadata && propertyMetadata.typeInfo && propertyMetadata.typeInfo.type)
 }
 
 export function alterCollectionPropertyMetadataForSingleItem<T>(propertyMeta?: PropertyMetadata<T> | null): PropertyMetadata<T> | undefined {

--- a/src/decorator/metadata/property-metadata.model.ts
+++ b/src/decorator/metadata/property-metadata.model.ts
@@ -1,7 +1,6 @@
-import { MapperForType } from '../../mapper/for-type/base.mapper'
-
 // def good
 import * as DynamoDB from 'aws-sdk/clients/dynamodb'
+import { MapperForType } from '../../mapper/for-type/base.mapper'
 import { Attribute } from '../../mapper/type/attribute.type'
 import { ModelConstructor } from '../../model/model-constructor'
 
@@ -40,6 +39,8 @@ export interface PropertyMetadata<T, R extends Attribute = Attribute> {
 
   mapper?: () => MapperForType<any, R>
 
+  mapperForSingleItem?: () => MapperForType<any, any>
+
   // maps the index name to the key type to describe for which GSI this property describes a key attribute
   keyForGSI?: Record<string, DynamoDB.KeyType>
 
@@ -54,4 +55,17 @@ export function hasGenericType(
   propertyMetadata?: PropertyMetadata<any, any>,
 ): propertyMetadata is PropertyMetadata<any, any> & { typeInfo: { genericType: ModelConstructor<any> } } {
   return !!(propertyMetadata && propertyMetadata.typeInfo && propertyMetadata.typeInfo.genericType)
+}
+
+export function alterCollectionPropertyMetadataForSingleItem<T>(propertyMeta?: PropertyMetadata<T> | null): PropertyMetadata<T> | undefined {
+  if (!propertyMeta) {
+    return
+  }
+  if (propertyMeta.mapper && propertyMeta.mapperForSingleItem) {
+    return { ...propertyMeta, mapper: propertyMeta.mapperForSingleItem }
+  }
+  if (propertyMeta.typeInfo && (propertyMeta.typeInfo.type === Set || propertyMeta.typeInfo.type === Array)) {
+    return
+  }
+  return { ...propertyMeta }
 }

--- a/src/decorator/metadata/property-metadata.spec.ts
+++ b/src/decorator/metadata/property-metadata.spec.ts
@@ -1,0 +1,50 @@
+// tslint:disable:no-non-null-assertion
+import { dateToStringMapper } from '../../mapper/custom'
+import { Model, Property } from '../impl'
+import { CollectionProperty } from '../impl/collection/collection-property.decorator'
+import { metadataForProperty } from './metadata-helper'
+import { alterCollectionPropertyMetadataForSingleItem } from './property-metadata.model'
+
+@Model()
+class TestModel {
+  @CollectionProperty()
+  myStringArray: string[]
+
+  @CollectionProperty({ itemMapper: dateToStringMapper })
+  myDateSet: Set<Date>
+
+  @Property()
+  myString: string
+}
+
+describe('alterCollectionPropertyMetadataForSingleItem', () => {
+  it('should return undefined when no itemMapper is defined', () => {
+    const propMeta = metadataForProperty(TestModel, 'myStringArray')!
+    expect(propMeta.mapperForSingleItem).toBeUndefined()
+    expect(alterCollectionPropertyMetadataForSingleItem(propMeta)).toBeUndefined()
+  })
+
+  it('should set the mapper for a single value when using itemMapper', () => {
+    const propMeta = metadataForProperty(TestModel, 'myDateSet')!
+    expect(propMeta.mapper).toBeDefined()
+    expect(propMeta.mapperForSingleItem).toBeDefined()
+
+    const alteredPropMeta = alterCollectionPropertyMetadataForSingleItem(propMeta)
+
+    expect(alteredPropMeta).toBeDefined()
+    expect(alteredPropMeta!.mapper).toBe(propMeta.mapperForSingleItem)
+  })
+
+  it('should not alter when non-collection', () => {
+    const propMeta = metadataForProperty(TestModel, 'myString')
+    expect(propMeta).toBeDefined()
+
+    const alteredPropMeta = alterCollectionPropertyMetadataForSingleItem(propMeta)
+    expect(alteredPropMeta).toEqual(propMeta)
+  })
+
+  it('should not throw when undefined or null was provided but return undefined', () => {
+    expect(alterCollectionPropertyMetadataForSingleItem()).toBe(undefined)
+    expect(alterCollectionPropertyMetadataForSingleItem(null)).toBe(undefined)
+  })
+})

--- a/src/dynamo/expression/type/condition-operator-alias.type.ts
+++ b/src/dynamo/expression/type/condition-operator-alias.type.ts
@@ -11,6 +11,7 @@ export type OperatorAlias =
   | 'type'
   | 'beginsWith'
   | 'contains'
+  | 'not_contains'
   | 'in'
   | 'between'
   | 'attributeExists'

--- a/src/dynamo/expression/type/condition-operator-to-alias-map.const.ts
+++ b/src/dynamo/expression/type/condition-operator-to-alias-map.const.ts
@@ -18,6 +18,7 @@ export const OPERATOR_TO_ALIAS_MAP: AliasedOperatorMapEntry = {
   attribute_exists: ['attributeExists', 'notNull'],
   attribute_type: 'type',
   contains: 'contains',
+  not_contains: 'not_contains',
   IN: 'in',
   begins_with: 'beginsWith',
   BETWEEN: 'between',

--- a/src/dynamo/expression/type/function-operator.type.ts
+++ b/src/dynamo/expression/type/function-operator.type.ts
@@ -4,5 +4,6 @@ export type FunctionOperator =
   | 'attribute_type'
   | 'begins_with'
   | 'contains'
+  | 'not_contains'
   | 'IN'
   | 'BETWEEN'

--- a/src/dynamo/request/update/update.request.spec.ts
+++ b/src/dynamo/request/update/update.request.spec.ts
@@ -1,4 +1,4 @@
-import { UpdateItemOutput } from 'aws-sdk/clients/dynamodb'
+import * as DynamoDB from 'aws-sdk/clients/dynamodb'
 import {
   ComplexModel,
   SimpleWithCompositePartitionKeyModel,
@@ -153,7 +153,7 @@ describe('update request', () => {
   })
 
   describe('logger', () => {
-    const sampleResponse: UpdateItemOutput = { Attributes: undefined }
+    const sampleResponse: DynamoDB.UpdateItemOutput = { Attributes: undefined }
     let logReceiver: jasmine.Spy
     let updateItemSpy: jasmine.Spy
     let req: UpdateRequest<SimpleWithPartitionKeyModel>

--- a/src/dynamo/transactwrite/transact-put.spec.ts
+++ b/src/dynamo/transactwrite/transact-put.spec.ts
@@ -18,7 +18,7 @@ describe('TransactPut', () => {
       addresses: [],
       numberValues: [42],
       info: { details: 'Foo Bar' },
-      topics: ['Table-Tennis'],
+      topics: new Set(['Table-Tennis']),
     }
     op = new TransactPut(UpdateModel, item)
   })

--- a/src/mapper/for-type/collection.mapper.ts
+++ b/src/mapper/for-type/collection.mapper.ts
@@ -31,21 +31,21 @@ function collectionFromDb(
   // if [L]ist
   if ('L' in attributeValue) {
     if (hasGenericType(propertyMetadata)) {
-      arr = (<ListAttribute>attributeValue).L.map(item => fromDb((<MapAttribute>item).M, propertyMetadata.typeInfo.genericType))
+      arr = attributeValue.L.map(item => fromDb((<MapAttribute>item).M, propertyMetadata.typeInfo.genericType))
     } else {
       // tslint:disable-next-line:no-unnecessary-callback-wrapper
-      arr = (<ListAttribute>attributeValue).L.map(v => fromDbOne(v))
+      arr = attributeValue.L.map(v => fromDbOne(v))
     }
     return explicitType && explicitType === Set ? new Set(arr) : arr
   }
 
   // if [(N|S|B)S]et
   if ('SS' in attributeValue) {
-    arr = (<StringSetAttribute>attributeValue).SS
+    arr = attributeValue.SS
   } else if ('NS' in attributeValue) {
-    arr = (<NumberSetAttribute>attributeValue).NS.map(parseFloat)
+    arr = attributeValue.NS.map(parseFloat)
   } else if ('BS' in attributeValue) {
-    arr = (<BinarySetAttribute>attributeValue).BS
+    arr = attributeValue.BS
   } else {
     throw new Error('No Collection Data (SS | NS | BS | L) was found in attribute data')
   }

--- a/src/mapper/for-type/collection.mapper.ts
+++ b/src/mapper/for-type/collection.mapper.ts
@@ -10,7 +10,7 @@ import {
   NumberSetAttribute,
   StringSetAttribute,
 } from '../type/attribute.type'
-import { detectCollectionTypeFromValue, isBufferType, isSet } from '../util'
+import { detectCollectionTypeFromValue, isBufferType, isHomogeneous, isSet } from '../util'
 import { MapperForType } from './base.mapper'
 
 type CollectionAttributeTypes =
@@ -26,87 +26,85 @@ function collectionFromDb(
 ): any[] | Set<any> {
   const explicitType = propertyMetadata && propertyMetadata.typeInfo ? propertyMetadata.typeInfo.type : null
 
-  if ('SS' in attributeValue) {
-    const arr: string[] = attributeValue.SS
-    return explicitType && explicitType === Array ? arr : new Set(arr)
-  }
+  let arr: any[]
 
-  if ('NS' in attributeValue) {
-    const arr: number[] = attributeValue.NS.map(parseFloat)
-    return explicitType && explicitType === Array ? arr : new Set(arr)
-  }
-
-  if ('BS' in attributeValue) {
-    const arr: any[] = attributeValue.BS
-    return explicitType && explicitType === Array ? arr : new Set(arr)
-  }
-
+  // if [L]ist
   if ('L' in attributeValue) {
-    let arr: any[]
     if (hasGenericType(propertyMetadata)) {
-      arr = attributeValue.L.map(item => fromDb((<MapAttribute>item).M, propertyMetadata.typeInfo.genericType))
+      arr = (<ListAttribute>attributeValue).L.map(item => fromDb((<MapAttribute>item).M, propertyMetadata.typeInfo.genericType))
     } else {
       // tslint:disable-next-line:no-unnecessary-callback-wrapper
-      arr = attributeValue.L.map(v => fromDbOne(v))
+      arr = (<ListAttribute>attributeValue).L.map(v => fromDbOne(v))
     }
     return explicitType && explicitType === Set ? new Set(arr) : arr
   }
 
-  throw new Error('No Collection Data (SS | NS | BS | L) was found in attribute data')
+  // if [(N|S|B)S]et
+  if ('SS' in attributeValue) {
+    arr = (<StringSetAttribute>attributeValue).SS
+  } else if ('NS' in attributeValue) {
+    arr = (<NumberSetAttribute>attributeValue).NS.map(parseFloat)
+  } else if ('BS' in attributeValue) {
+    arr = (<BinarySetAttribute>attributeValue).BS
+  } else {
+    throw new Error('No Collection Data (SS | NS | BS | L) was found in attribute data')
+  }
+  return explicitType && explicitType === Array ? arr : new Set(arr)
 }
 
 function collectionToDb(
   propertyValue: any[] | Set<any>,
   propertyMetadata?: PropertyMetadata<any, CollectionAttributeTypes>,
 ): CollectionAttributeTypes | null {
-  if (Array.isArray(propertyValue) || isSet(propertyValue)) {
-    let collectionType: AttributeType
-    // detect collection type
-    if (propertyMetadata) {
-      // based on metadata
-      collectionType = detectCollectionTypeFromMetadata(propertyMetadata, propertyValue)
-    } else {
-      // based on value
-      collectionType = detectCollectionTypeFromValue(propertyValue)
-    }
-
-    // convert to array if we deal with a set for same behaviour
-    propertyValue = isSet(propertyValue) ? Array.from(propertyValue) : propertyValue
-
-    // empty values are not allowed for S(et) types only for L(ist)
-    if ((collectionType === 'SS' || collectionType === 'NS' || collectionType === 'BS') && propertyValue.length === 0) {
-      return null
-    }
-
-    // do the mapping depending on type
-    switch (collectionType) {
-      case 'SS':
-        return { SS: propertyValue }
-      case 'NS':
-        return { NS: propertyValue.map(num => num.toString()) }
-      case 'BS':
-        return { BS: propertyValue }
-      case 'L':
-        if (hasGenericType(propertyMetadata)) {
-          return {
-            L: propertyValue.map(value => ({
-              M: toDb(value, propertyMetadata.typeInfo.genericType),
-            })),
-          }
-        } else {
-          return {
-            L: propertyValue
-            // tslint:disable-next-line:no-unnecessary-callback-wrapper
-              .map(v => toDbOne(v))
-              .filter(notNull),
-          }
-        }
-      default:
-        throw new Error(`Collection type must be one of SS | NS | BS | L found type ${collectionType}`)
-    }
-  } else {
+  if (!(Array.isArray(propertyValue) || isSet(propertyValue))) {
     throw new Error(`Given value must be either Array or Set ${propertyValue}`)
   }
+
+  let collectionType: AttributeType
+  // detect collection type
+  if (propertyMetadata) {
+    // based on metadata
+    collectionType = detectCollectionTypeFromMetadata(propertyMetadata, propertyValue)
+  } else {
+    // based on value
+    collectionType = detectCollectionTypeFromValue(propertyValue)
+  }
+
+  // convert to array if we deal with a set for same behaviour
+  propertyValue = isSet(propertyValue) ? Array.from(propertyValue) : propertyValue
+
+  // empty values are not allowed for S(et) types only for L(ist)
+  if ((collectionType === 'SS' || collectionType === 'NS' || collectionType === 'BS') && propertyValue.length === 0) {
+    return null
+  }
+
+  // do the mapping depending on type
+  switch (collectionType) {
+    case 'SS':
+      return { SS: propertyValue }
+    case 'NS':
+      return { NS: propertyValue.map(num => num.toString()) }
+    case 'BS':
+      return { BS: propertyValue }
+    case 'L':
+      if (hasGenericType(propertyMetadata)) {
+        return {
+          L: propertyValue.map(value => ({
+            M: toDb(value, propertyMetadata.typeInfo.genericType),
+          })),
+        }
+      } else {
+        return {
+          L: propertyValue
+          // tslint:disable-next-line:no-unnecessary-callback-wrapper
+            .map(v => toDbOne(v))
+            .filter(notNull),
+        }
+      }
+    default:
+      throw new Error(`Collection type must be one of SS | NS | BS | L found type ${collectionType}`)
+  }
+
 }
 
 export const CollectionMapper: MapperForType<any[] | Set<any>, CollectionAttributeTypes> = {
@@ -116,43 +114,57 @@ export const CollectionMapper: MapperForType<any[] | Set<any>, CollectionAttribu
 
 
 function detectCollectionTypeFromMetadata(propertyMetadata: PropertyMetadata<any, CollectionAttributeTypes>, propertyValue: any): AttributeCollectionType {
-  let collectionType: AttributeType
   const explicitType = propertyMetadata && propertyMetadata.typeInfo ? propertyMetadata.typeInfo.type : null
-  switch (explicitType) {
-    case Array:
-      collectionType = 'L'
-      break
-    case Set:
-      if (propertyMetadata.isSortedCollection) {
-        // only the L(ist) type preserves order
-        collectionType = 'L'
-      } else {
-        if (hasGenericType(propertyMetadata)) {
-          // generic type of Set is defined, so decide based on the generic type which db set type should be used
-          if (isBufferType(propertyMetadata.typeInfo.genericType)) {
-            collectionType = 'BS'
-          } else {
-            switch (propertyMetadata.typeInfo.genericType) {
-              case String:
-                collectionType = 'SS'
-                break
-              case Number:
-                collectionType = 'NS'
-                break
-              default:
-                // fallback to list if the type is not one of String or Number
-                collectionType = 'L'
-            }
-          }
-        } else {
-          // auto detect based on set item values
-          collectionType = detectCollectionTypeFromValue(propertyValue)
-        }
-      }
-      break
-    default:
-      throw new Error(`only 'Array' and 'Set' are valid values for explicit type, found ${explicitType}`)
+
+  if (!(explicitType === Array || explicitType === Set)) {
+    throw new Error(`only 'Array' and 'Set' are valid values for explicit type, found ${explicitType}`)
   }
 
-  return collectionType
+  if (propertyMetadata.isSortedCollection) {
+    // only the [L]ist type preserves the order
+    return 'L'
+  }
+
+  if (hasGenericType(propertyMetadata) /* aka ItemType */) {
+    // generic type of Set is defined, so decide based on the generic type which db set type should be used
+    if (isBufferType(propertyMetadata.typeInfo.genericType)) {
+      return 'BS'
+    }
+    switch (propertyMetadata.typeInfo.genericType) {
+      case String:
+        return 'SS'
+      case Number:
+        return 'NS'
+      default:
+        // fallback to list if the type is not one of String or Number
+        return 'L'
+    }
+  }
+
+  // by value (But we know, how to parse it (array or set) which differs from 'detectCollectionTypeFromValue')
+  if (explicitType === Array) {
+    return 'L'
+  }
+  if ([...propertyValue].length === 0) {
+    /*
+     * an empty Set will not be persisted so we just return an arbitrary Set type, it is only important that it is one of
+     * S(et)
+     */
+    return 'SS'
+  }
+  else {
+    const { homogeneous, type } = isHomogeneous(propertyValue)
+    if (homogeneous) {
+      switch (type) {
+        case 'S':
+          return 'SS'
+        case 'N':
+          return 'NS'
+        case 'B':
+          return 'BS'
+      }
+    }
+    return 'L'
+  }
+
 }

--- a/src/mapper/for-type/object.mapper.ts
+++ b/src/mapper/for-type/object.mapper.ts
@@ -1,10 +1,10 @@
-import { PropertyMetadata } from '../../decorator/metadata/property-metadata.model'
+import { hasType, PropertyMetadata } from '../../decorator/metadata/property-metadata.model'
 import { fromDb, toDb } from '../mapper'
 import { Attributes, MapAttribute } from '../type/attribute.type'
 import { MapperForType } from './base.mapper'
 
 function objectFromDb(val: MapAttribute, propertyMetadata?: PropertyMetadata<any, MapAttribute>): any {
-  if (propertyMetadata && propertyMetadata.typeInfo && propertyMetadata.typeInfo.isCustom) {
+  if (hasType(propertyMetadata)) {
     return fromDb(val.M, propertyMetadata.typeInfo.type)
   } else {
     return fromDb(val.M)
@@ -13,7 +13,7 @@ function objectFromDb(val: MapAttribute, propertyMetadata?: PropertyMetadata<any
 
 function objectToDb(modelValue: any, propertyMetadata?: PropertyMetadata<any, MapAttribute>): MapAttribute {
   let value: Attributes
-  if (propertyMetadata && propertyMetadata.typeInfo && propertyMetadata.typeInfo.isCustom) {
+  if (hasType(propertyMetadata)) {
     value = toDb(modelValue, propertyMetadata.typeInfo.type)
   } else {
     value = toDb(modelValue)

--- a/src/mapper/mapper.spec.ts
+++ b/src/mapper/mapper.spec.ts
@@ -111,7 +111,7 @@ describe('Mapper', () => {
 
       it('enum (propertyMetadata -> no enum decorator)', () => {
         const attrValue: Attribute = <MapAttribute>toDbOne(Type.FirstType, <any>{
-          typeInfo: { type: Object, isCustom: true },
+          typeInfo: { type: Object },
         })!
         expect(attrValue).toBeDefined()
         expect(keyOf(attrValue)).toBe('M')
@@ -128,7 +128,6 @@ describe('Mapper', () => {
           isSortedCollection: true,
           typeInfo: {
             type: Array,
-            isCustom: true,
           },
         }
         const attrValue = <ListAttribute<StringAttribute>>toDbOne(['foo', 'bar'], <any>propertyMetadata)!
@@ -194,7 +193,6 @@ describe('Mapper', () => {
         const meta: PropertyMetadata<any, any> = <any>{
           typeInfo: {
             type: Set,
-            isCustom: true,
           },
         }
         const attrValue = toDbOne(new Set(['foo', 'bar', 25]), meta)
@@ -213,7 +211,6 @@ describe('Mapper', () => {
       it('Set of objects with decorator -> L(ist)', () => {
         const meta: PropertyMetadata<any> = <any>{
           typeInfo: {
-            isCustom: true,
             type: Set,
           },
         }
@@ -329,7 +326,7 @@ describe('Mapper', () => {
 
       it('SS -> array', () => {
         const propertyMetadata = <Partial<PropertyMetadata<any>>>{
-          typeInfo: { type: Array, isCustom: true },
+          typeInfo: { type: Array },
         }
         const attrValue = { SS: ['foo', 'bar'] }
         const arr = fromDbOne<string[]>(attrValue, <any>propertyMetadata)
@@ -349,7 +346,7 @@ describe('Mapper', () => {
 
       it('NS -> array', () => {
         const propertyMetadata = <Partial<PropertyMetadata<any>>>{
-          typeInfo: { type: Array, isCustom: true },
+          typeInfo: { type: Array },
         }
         const attrValue = { NS: ['45', '2'] }
         const arr = fromDbOne<number[]>(attrValue, <any>propertyMetadata)
@@ -371,7 +368,7 @@ describe('Mapper', () => {
 
       it('L -> set', () => {
         const propertyMetadata = <Partial<PropertyMetadata<any>>>{
-          typeInfo: { type: Set, isCustom: true },
+          typeInfo: { type: Set },
         }
         const attrValue = { L: [{ S: 'foo' }, { N: '45' }, { BOOL: true }] }
         const set = fromDbOne<Set<any>>(attrValue, <any>propertyMetadata)

--- a/src/mapper/mapper.spec.ts
+++ b/src/mapper/mapper.spec.ts
@@ -800,7 +800,6 @@ describe('Mapper', () => {
         }
 
         const toDbValue = toDb(model, ModelWithEmptyValues)
-        console.log(toDbValue)
 
         // expect(Object.keys(toDbValue).length).toBe(4)
 

--- a/src/mapper/mapper.ts
+++ b/src/mapper/mapper.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 import { hasSortKey, Metadata } from '../decorator/metadata/metadata'
 import { metadataForClass, metadataForProperty } from '../decorator/metadata/metadata-helper'
-import { Key, PropertyMetadata } from '../decorator/metadata/property-metadata.model'
+import { hasType, Key, PropertyMetadata } from '../decorator/metadata/property-metadata.model'
 import { ModelConstructor } from '../model'
 import { MapperForType } from './for-type/base.mapper'
 import { BooleanMapper } from './for-type/boolean.mapper'
@@ -84,10 +84,9 @@ export function toDb<T>(item: T, modelConstructor?: ModelConstructor<T>): Attrib
 }
 
 export function toDbOne(propertyValue: any, propertyMetadata?: PropertyMetadata<any>): Attribute | null {
-  const explicitType: AttributeValueType | null =
-    propertyMetadata && propertyMetadata.typeInfo && propertyMetadata.typeInfo.isCustom
-      ? propertyMetadata.typeInfo.type
-      : null
+  const explicitType: AttributeValueType | null = hasType(propertyMetadata)
+    ? propertyMetadata.typeInfo.type
+    : null
   const type: AttributeValueType = explicitType || typeOf(propertyValue)
 
   const mapper = propertyMetadata && propertyMetadata.mapper ? propertyMetadata.mapper() : forType(type)
@@ -215,10 +214,7 @@ export function fromDb<T>(attributeMap: Attributes<T>, modelConstructor?: ModelC
 }
 
 export function fromDbOne<T>(attributeValue: Attribute, propertyMetadata?: PropertyMetadata<any, any>): T {
-  const explicitType: AttributeValueType | null =
-    propertyMetadata && propertyMetadata.typeInfo && propertyMetadata.typeInfo.isCustom
-      ? propertyMetadata.typeInfo.type
-      : null
+  const explicitType: AttributeValueType | null = hasType(propertyMetadata) ? propertyMetadata.typeInfo.type : null
   const type: AttributeValueType = explicitType || typeOfFromDb(attributeValue)
 
   if (explicitType) {

--- a/src/mapper/type/attribute.type.ts
+++ b/src/mapper/type/attribute.type.ts
@@ -33,6 +33,7 @@ export interface NumberAttribute {
 
 /**
  * An attribute of type Binary. For example:  "B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"
+ * TODO LOW:BINARY check for all possible types
  */
 export interface BinaryAttribute {
   B: Buffer | Uint8Array | {} | string

--- a/src/mapper/type/attribute.type.ts
+++ b/src/mapper/type/attribute.type.ts
@@ -6,7 +6,7 @@ export type Attribute =
   | NumberSetAttribute
   | BinarySetAttribute
   | MapAttribute
-  | ListAttribute
+  | ListAttribute<any>
   | NullAttribute
   | BooleanAttribute
 
@@ -56,7 +56,7 @@ export interface NumberSetAttribute {
  * An attribute of type Binary Set. For example:  "BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]
  */
 export interface BinarySetAttribute {
-  BS: BinaryAttribute[]
+  BS: Array<Buffer | Uint8Array | {} | string>
 }
 
 /**
@@ -71,9 +71,10 @@ export interface MapAttribute<T = {}> {
  * An attribute of type List. For example:  "L": ["Cookies", "Coffee", 3.14159]
  */
 
-export interface ListAttribute {
-  L: Attribute[]
+export interface ListAttribute<T extends Attribute = Attribute> {
+  L: T[]
 }
+
 
 /**
  * An attribute of type Null. For example:  "NULL": true

--- a/src/mapper/util.spec.ts
+++ b/src/mapper/util.spec.ts
@@ -56,7 +56,7 @@ describe('Util', () => {
     })
   })
 
-  describe('detect collection type', () => {
+  describe('detect collection type without property metadata', () => {
     it('set (empty)', () => {
       const collection: Set<string> = new Set()
       expect(detectCollectionTypeFromValue(collection)).toBe('SS')
@@ -72,19 +72,19 @@ describe('Util', () => {
       expect(detectCollectionTypeFromValue(collection)).toBe('NS')
     })
 
-    it('set with object values', () => {
-      const collection: Set<any> = new Set([{ foo: 'foo' }, { bar: 'bar' }])
-      expect(detectCollectionTypeFromValue(collection)).toBe('L')
-    })
-
-    it('set with values of different type', () => {
-      const collection: Set<any> = new Set(['foo', 5])
-      expect(detectCollectionTypeFromValue(collection)).toBe('L')
-    })
-
     it('set with no values', () => {
       const collection: Set<any> = new Set()
       expect(detectCollectionTypeFromValue(collection)).toBe('SS')
+    })
+
+    it('set with object values should throw', () => {
+      const collection: Set<any> = new Set([{ foo: 'foo' }, { bar: 'bar' }])
+      expect(() => detectCollectionTypeFromValue(collection)).toThrow()
+    })
+
+    it('set with values of different type should throw', () => {
+      const collection: Set<any> = new Set(['foo', 5])
+      expect(() => detectCollectionTypeFromValue(collection)).toThrow()
     })
   })
 

--- a/src/mapper/util.ts
+++ b/src/mapper/util.ts
@@ -34,20 +34,6 @@ const BUFFER_TYPES = [
  */
 export function detectCollectionTypeFromValue(collection: any[] | Set<any>): AttributeCollectionType {
   if (Array.isArray(collection)) {
-    if (collection.length) {
-      if (collection.every(isString)) {
-        return 'SS'
-      }
-
-      if (collection.every(isNumber)) {
-        return 'NS'
-      }
-
-      if (collection.every(isBinary)) {
-        return 'BS'
-      }
-    }
-
     return 'L'
   } else if (isSet(collection)) {
     if (collection.size) {
@@ -61,21 +47,21 @@ export function detectCollectionTypeFromValue(collection: any[] | Set<any>): Att
           case 'B':
             return 'BS'
           default:
-            return 'L'
+            throw new Error(`"Set<CustomType>" without decorator is not supported. Add the @CollectionProperty() decorator (optionally with {itemType:CustomType}) for a Set<->[L]ist mapping)`)
         }
       } else {
         // sets can not contain items with different types (heterogeneous)
-        return 'L'
+        throw new Error(`"Set with values of different types without decorator is not supported. Use an array instead.`)
       }
     } else {
       /*
-       * an empty Set will not be persisted so we just return a random Set type, it is only important that it is one of
+       * an empty Set will not be persisted so we just return an arbitrary Set type, it is only important that it is one of
        * S(et)
        */
       return 'SS'
     }
   } else {
-    throw new Error('given collection was no array or Set -> type could not be detected')
+    throw new Error('given collection was neither array nor Set -> type could not be detected')
   }
 }
 

--- a/src/mapper/wrap-mapper-for-collection.function.spec.ts
+++ b/src/mapper/wrap-mapper-for-collection.function.spec.ts
@@ -1,0 +1,135 @@
+// tslint:disable:max-classes-per-file
+import { FailModel } from '../../test/models/fail-model.model'
+import { ModelWithCollections } from '../../test/models/model-with-collections.model'
+import { FormId, formIdMapper, FormType } from '../../test/models/real-world'
+import { MapperForType } from './for-type/base.mapper'
+import { fromDb, toDb } from './mapper'
+import { Attributes, NumberAttribute, StringAttribute } from './type/attribute.type'
+import {
+  arrayToListAttribute,
+  arrayToSetAttribute,
+  listAttributeToArray,
+  setAttributeToArray,
+} from './wrap-mapper-for-collection.function'
+
+class MyNumber {
+  value: number
+}
+
+class MyChar {
+  value: string // char
+}
+
+const myNumberToStringAttrMapper: MapperForType<MyNumber, StringAttribute> = {
+  toDb: propertyValue => ({ S: `${propertyValue.value}` }),
+  fromDb: attributeValue => ({ value: parseInt(attributeValue.S, 10) }),
+}
+const myCharToNumberAttrMapper: MapperForType<MyChar, NumberAttribute> = {
+  toDb: propertyValue => ({ N: `${propertyValue.value.charCodeAt(0)}` }),
+  fromDb: attributeValue => ({ value: String.fromCharCode(parseInt(attributeValue.N, 10)) }),
+}
+
+describe('arrayToListAttribute', () => {
+  it('should map empty array to empty (L)ist', () => {
+    expect(arrayToListAttribute(myNumberToStringAttrMapper)([])).toEqual({ L: [] })
+  })
+  it('should map array to list with given mapper', () => {
+    expect(arrayToListAttribute(myNumberToStringAttrMapper)([{ value: 7 }])).toEqual({ L: [{ S: '7' }] })
+  })
+})
+
+describe('listAttributeToArray', () => {
+  it('should parse empty list to empty array', () => {
+    expect(listAttributeToArray(myNumberToStringAttrMapper)({ L: [] })).toEqual([])
+  })
+  it('should parse list to array with given mapper', () => {
+    expect(listAttributeToArray(myNumberToStringAttrMapper)({ L: [{ S: '7' }] })).toEqual([{ value: 7 }])
+  })
+})
+
+describe('arrayToSetAttribute', () => {
+  it('should map empty array to null', () => {
+    expect(arrayToSetAttribute(myNumberToStringAttrMapper)([])).toEqual(null)
+  })
+  it('should map array to (S)et', () => {
+    expect(arrayToSetAttribute(myNumberToStringAttrMapper)([{ value: 7 }])).toEqual({ SS: ['7'] })
+    expect(arrayToSetAttribute(myCharToNumberAttrMapper)([{ value: 'A' }])).toEqual({ NS: ['65'] })
+  })
+})
+
+describe('setAttributeToArray', () => {
+  it('should parse (S)et to array', () => {
+    expect(setAttributeToArray(myNumberToStringAttrMapper)({ SS: ['7'] })).toEqual([{ value: 7 }])
+    expect(setAttributeToArray(myCharToNumberAttrMapper)({ NS: ['65'] })).toEqual([{ value: 'A' }])
+  })
+})
+
+describe('for collection wrapped mappers', () => {
+  describe('fromDb', () => {
+    let aFormId: FormId
+    beforeEach(() => {
+      aFormId = new FormId(FormType.REQUEST, 55, 2020)
+    })
+
+    it('array to (L)ist (itemMapper, sorted)', () => {
+      const dbObj: Attributes<ModelWithCollections> = {
+        arrayOfFormIdToListWithStrings: { L: [formIdMapper.toDb(aFormId)] },
+      }
+      expect(fromDb(dbObj, ModelWithCollections)).toEqual({ arrayOfFormIdToListWithStrings: [aFormId] })
+    })
+    it('set to (L)ist (itemMapper, sorted)', () => {
+      const dbObj: Attributes<ModelWithCollections> = {
+        setOfFormIdToListWithStrings: { L: [formIdMapper.toDb(aFormId)] },
+      }
+      expect(fromDb(dbObj, ModelWithCollections)).toEqual({ setOfFormIdToListWithStrings: new Set([aFormId]) })
+    })
+
+    it('array to (S)et (itemMapper)', () => {
+      const dbObj: Attributes<ModelWithCollections> = { arrayOfFormIdToSet: { SS: [FormId.unparse(aFormId)] } }
+      expect(fromDb(dbObj, ModelWithCollections)).toEqual({ arrayOfFormIdToSet: [aFormId] })
+    })
+    it('set to (S)et (itemMapper)', () => {
+      const dbObj: Attributes<ModelWithCollections> = { setOfFormIdToSet: { SS: [FormId.unparse(aFormId)] } }
+      expect(fromDb(dbObj, ModelWithCollections)).toEqual({ setOfFormIdToSet: new Set([aFormId]) })
+    })
+
+    it('should throw when not a (S)et attribute', () => {
+      const dbObj: Attributes<FailModel> = { myFail: { M: { id: { S: '42' } } } }
+      expect(() => fromDb(dbObj, FailModel)).toThrow()
+    })
+  })
+
+  describe('toDb', () => {
+    let aFormId: FormId
+
+    beforeEach(() => {
+      aFormId = new FormId(FormType.REQUEST, 55, 2020)
+    })
+
+    it('array to (L)ist (itemMapper, sorted)', () => {
+      expect(toDb({ arrayOfFormIdToListWithStrings: [aFormId] }, ModelWithCollections)).toEqual({
+        arrayOfFormIdToListWithStrings: { L: [formIdMapper.toDb(aFormId)] },
+      })
+    })
+    it('set to (L)ist (itemMapper, sorted)', () => {
+      expect(toDb({ setOfFormIdToListWithStrings: new Set([aFormId]) }, ModelWithCollections)).toEqual({
+        setOfFormIdToListWithStrings: { L: [formIdMapper.toDb(aFormId)] },
+      })
+    })
+
+    it('array to (S)et (itemMapper)', () => {
+      expect(toDb({ arrayOfFormIdToSet: [aFormId] }, ModelWithCollections)).toEqual({
+        arrayOfFormIdToSet: { SS: [FormId.unparse(aFormId)] },
+      })
+    })
+    it('set to (S)et (itemMapper)', () => {
+      expect(toDb({ setOfFormIdToSet: new Set([aFormId]) }, ModelWithCollections)).toEqual({
+        setOfFormIdToSet: { SS: [FormId.unparse(aFormId)] },
+      })
+    })
+
+    it('should throw when wrong mapper', () => {
+      expect(() => toDb({ myFail: [{ id: 42 }] }, FailModel)).toThrow()
+    })
+  })
+})

--- a/src/mapper/wrap-mapper-for-collection.function.ts
+++ b/src/mapper/wrap-mapper-for-collection.function.ts
@@ -1,0 +1,114 @@
+import { notNull } from '../helper'
+import { MapperForType } from './for-type/base.mapper'
+import {
+  BinaryAttribute,
+  BinarySetAttribute,
+  ListAttribute,
+  NumberAttribute,
+  NumberSetAttribute,
+  StringAttribute,
+  StringSetAttribute,
+} from './type/attribute.type'
+
+export type SetAttributeOf<A extends StringAttribute | NumberAttribute | BinaryAttribute> = A extends StringAttribute
+  ? StringSetAttribute
+  : A extends NumberAttribute
+    ? NumberSetAttribute
+    : BinarySetAttribute
+
+
+export function arrayToListAttribute<T, A extends StringAttribute | NumberAttribute | BinaryAttribute>(customMapper: MapperForType<T, A>) {
+  return (values: T[]): ListAttribute<A> | null => {
+    const mapped = values
+      .map(v => customMapper.toDb(v))
+      .filter(notNull)
+    return <ListAttribute<A>>{ L: mapped }
+  }
+}
+
+export function listAttributeToArray<T, A extends StringAttribute | NumberAttribute | BinaryAttribute>(customMapper: MapperForType<T, A>) {
+  return (attributeValues: ListAttribute<A>): T[] => attributeValues.L.map(i => customMapper.fromDb(i))
+}
+
+export function setAttributeToArray<T, A extends StringAttribute | NumberAttribute | BinaryAttribute>(customMapper: MapperForType<T, A>) {
+  return (attributeValues: SetAttributeOf<A>): T[] => {
+    switch (Object.keys(attributeValues)[0]) {
+      case 'SS':
+        return (<StringSetAttribute>attributeValues).SS.map(v => customMapper.fromDb(<A>{ S: v }))
+      case 'NS':
+        return (<NumberSetAttribute>attributeValues).NS.map(v => customMapper.fromDb(<A>{ N: v }))
+      case 'BS':
+        return (<BinarySetAttribute>attributeValues).BS.map(v => customMapper.fromDb(<A>{ B: v }))
+      default:
+        throw new Error(`given attribute (${JSON.stringify(attributeValues)}) value is not a SetAttribute`)
+    }
+  }
+}
+
+export function arrayToSetAttribute<T, A extends StringAttribute | NumberAttribute | BinaryAttribute>(customMapper: MapperForType<T, A>) {
+  return (values: T[]): SetAttributeOf<A> | null => {
+    const mapped = values
+      .map(v => customMapper.toDb(v))
+      .filter(notNull)
+    if (mapped.length === 0) {
+      return null
+    }
+    switch (Object.keys(mapped[0])[0]) {
+      case 'S':
+        return <SetAttributeOf<A>>{ SS: (<StringAttribute[]>mapped).map(sa => sa.S) }
+      case 'N':
+        return <SetAttributeOf<A>>{ NS: (<NumberAttribute[]>mapped).map(na => na.N) }
+      case 'B':
+        return <SetAttributeOf<A>>{ BS: (<BinaryAttribute[]>mapped).map(ba => ba.B) }
+      default:
+        throw new Error('values given are not of type string, number or binary after applying the custom mapper')
+    }
+  }
+}
+
+
+/**
+ * returns a function which takes a Set which will be spread when applied to the given function
+ * @param fn
+ */
+function spreadSetAndApplyToFn<T, R>(fn: (values: T[]) => R) {
+  return (values: Set<T>) => fn([...values])
+}
+
+/**
+ * returns a function which will execute the given function and wraps its return value in a Set
+ * @param fn
+ */
+function applyFnWrapWithSet<A, R>(fn: (arg: A) => R[]) {
+  return (arg: A) => new Set(fn(arg))
+}
+
+
+export function wrapMapperForDynamoSetJsArray<T, A extends StringAttribute | NumberAttribute | BinaryAttribute>(customMapper: MapperForType<T, A>): MapperForType<T[], SetAttributeOf<A>> {
+  return {
+    fromDb: setAttributeToArray(customMapper),
+    toDb: arrayToSetAttribute(customMapper),
+  }
+}
+
+export function wrapMapperForDynamoSetJsSet<T, A extends StringAttribute | NumberAttribute | BinaryAttribute>(customMapper: MapperForType<T, A>): MapperForType<Set<T>, SetAttributeOf<A>> {
+  return {
+    fromDb: applyFnWrapWithSet(setAttributeToArray(customMapper)),
+    toDb: spreadSetAndApplyToFn(arrayToSetAttribute(customMapper)),
+  }
+}
+
+export function wrapMapperForDynamoListJsArray<T, A extends StringAttribute | NumberAttribute | BinaryAttribute>(customMapper: MapperForType<T, A>): MapperForType<T[], ListAttribute<A>> {
+  return {
+    fromDb: listAttributeToArray(customMapper),
+    toDb: arrayToListAttribute(customMapper),
+  }
+}
+
+export function wrapMapperForDynamoListJsSet<T, A extends StringAttribute | NumberAttribute | BinaryAttribute>(customMapper: MapperForType<T, A>): MapperForType<Set<T>, ListAttribute<A>> {
+  return {
+    fromDb: applyFnWrapWithSet(listAttributeToArray(customMapper)),
+    toDb: spreadSetAndApplyToFn(arrayToListAttribute(customMapper)),
+  }
+}
+

--- a/test/models/complex.model.ts
+++ b/test/models/complex.model.ts
@@ -1,13 +1,5 @@
-import {
-  DateProperty,
-  Model,
-  PartitionKey,
-  Property,
-  SortedSet,
-  SortKey,
-  Transient,
-  TypedSet,
-} from '../../src/dynamo-easy'
+import { CollectionProperty } from '../../src/decorator/impl/collection/collection-property.decorator'
+import { DateProperty, Model, PartitionKey, Property, SortKey, Transient } from '../../src/dynamo-easy'
 import { NestedObject } from './nested-object.model'
 
 @Model({ tableName: 'complex_model' })
@@ -25,20 +17,17 @@ export class ComplexModel {
   @Property({ name: 'isActive' })
   active: boolean
 
-  @TypedSet()
+  @CollectionProperty()
   set: Set<string>
-
-  // @Type(Map)
-  // myMap: Map<String, String>;
 
   /*
    * actually this value is always mapped to an array, so the typing is not correct,
    * we still leave it to check if it works
    */
-  @SortedSet()
+  @CollectionProperty({ sorted: true })
   sortedSet: Set<string>
 
-  @SortedSet(NestedObject)
+  @CollectionProperty({ sorted: true, itemType: NestedObject })
   sortedComplexSet: Set<NestedObject>
 
   @Property()

--- a/test/models/employee.model.ts
+++ b/test/models/employee.model.ts
@@ -1,4 +1,5 @@
-import { DateProperty, Model, SortedSet } from '../../src/dynamo-easy'
+import { CollectionProperty } from '../../src/decorator/impl/collection/collection-property.decorator'
+import { DateProperty, Model } from '../../src/dynamo-easy'
 
 @Model()
 export class Employee {
@@ -9,7 +10,7 @@ export class Employee {
   @DateProperty()
   createdAt: Date | null
 
-  @SortedSet()
+  @CollectionProperty({ sorted: true })
   sortedSet: Set<string>
 
   constructor(name: string, age: number, createdAt: Date | null, sortedListValues: any[] | null) {

--- a/test/models/fail-model.model.ts
+++ b/test/models/fail-model.model.ts
@@ -1,0 +1,21 @@
+import { Model } from '../../src/decorator/impl'
+
+// tslint:disable:max-classes-per-file
+import { CollectionProperty } from '../../src/decorator/impl/collection/collection-property.decorator'
+import { MapAttribute, MapperForType, StringAttribute } from '../../src/mapper'
+
+const strangeMapper: MapperForType<FailModelNestedFail, MapAttribute> = {
+  toDb: propertyValue => ({ M: { id: { S: `${propertyValue}` } } }),
+  fromDb: attributeValue => ({ id: parseInt((<StringAttribute>attributeValue.M.id).S, 10) }),
+}
+
+class FailModelNestedFail {
+  id: number
+}
+
+@Model()
+export class FailModel {
+  // array <-> (S)et
+  @CollectionProperty({ itemMapper: <any>strangeMapper })
+  myFail: FailModelNestedFail[]
+}

--- a/test/models/model-with-collections.model.ts
+++ b/test/models/model-with-collections.model.ts
@@ -1,0 +1,48 @@
+import { Model } from '../../src/decorator/impl'
+import { CollectionProperty } from '../../src/decorator/impl/collection/collection-property.decorator'
+import { NestedModelWithDate } from './nested-model-with-date.model'
+import { NestedObject } from './nested-object.model'
+import { FormId, formIdMapper } from './real-world'
+
+@Model()
+export class ModelWithCollections {
+  // ================================================================
+  // should be mapped to (L)ist of (M)aps since itemType is complex
+  @CollectionProperty({ itemType: NestedModelWithDate })
+  arrayOfNestedModelToList: NestedModelWithDate[]
+
+  @CollectionProperty({ itemType: NestedModelWithDate })
+  setOfNestedModelToList: Set<NestedModelWithDate>
+
+  // ==============================================================================
+  // should be mapped to (L)ist of (S)trings since it needs to preserve the order
+  @CollectionProperty({ sorted: true, itemMapper: formIdMapper })
+  arrayOfFormIdToListWithStrings: FormId[]
+
+  @CollectionProperty({ sorted: true, itemMapper: formIdMapper })
+  setOfFormIdToListWithStrings: Set<FormId>
+
+  // ===========================================================================
+  // should be mapped to (L)ist of (M)aps since it complex type without mapper
+  @CollectionProperty()
+  arrayOfObjectsToList: NestedObject[]
+
+  @CollectionProperty()
+  setOfObjectsToList: Set<NestedObject>
+
+  // ====================================================================
+  // should be mapped to (String)(S)et since the itemMapper is provided
+  @CollectionProperty({ itemMapper: formIdMapper })
+  arrayOfFormIdToSet: FormId[]
+
+  @CollectionProperty({ itemMapper: formIdMapper })
+  setOfFormIdToSet: Set<FormId>
+
+  // should be mapped to List since it is an array
+  @CollectionProperty()
+  arrayOfStringToSet: string[]
+
+  // should be mapped to Set
+  @CollectionProperty()
+  setOfStringToSet: Set<string>
+}

--- a/test/models/nested-complex.model.ts
+++ b/test/models/nested-complex.model.ts
@@ -1,9 +1,10 @@
-import { Model, SortedSet } from '../../src/dynamo-easy'
+import { CollectionProperty } from '../../src/decorator/impl/collection/collection-property.decorator'
+import { Model } from '../../src/dynamo-easy'
 
 @Model()
 export class NestedComplexModel {
   // should be mapped to a L DynamoDb Type to preserve the order
-  @SortedSet()
+  @CollectionProperty({ sorted: true })
   sortedSet: Set<string>
 
   constructor() {

--- a/test/models/nested-model-with-date.model.ts
+++ b/test/models/nested-model-with-date.model.ts
@@ -1,0 +1,7 @@
+import { DateProperty, Model } from '../../src/decorator/impl'
+
+@Model()
+export class NestedModelWithDate {
+  @DateProperty()
+  updated: Date
+}

--- a/test/models/organization.model.ts
+++ b/test/models/organization.model.ts
@@ -1,14 +1,5 @@
-import {
-  DateProperty,
-  Model,
-  PartitionKey,
-  Property,
-  SortedSet,
-  SortKey,
-  Transient,
-  TypedArray,
-  TypedSet,
-} from '../../src/dynamo-easy'
+import { CollectionProperty } from '../../src/decorator/impl/collection/collection-property.decorator'
+import { DateProperty, Model, PartitionKey, Property, SortKey, Transient } from '../../src/dynamo-easy'
 import { Employee } from './employee.model'
 
 // tslint:disable:max-classes-per-file
@@ -22,7 +13,7 @@ export class Birthday {
   @DateProperty()
   date: Date
 
-  @TypedArray(Gift)
+  @CollectionProperty({ itemType: Gift })
   presents: Gift[]
 
   constructor(date: Date, ...gifts: string[]) {
@@ -79,14 +70,14 @@ export class Organization {
    * ARRAY
    */
 
-  // simple type (no metadata required)
+  // simple type -> L(ist) (no metadata required)
   domains: string[]
 
   // simple type, mixed (no metadata required)
   randomDetails: any[]
 
   // complex type (requires metadata)
-  @TypedArray(Employee)
+  @CollectionProperty({ itemType: Employee })
   employees: Employee[]
 
   /*
@@ -98,18 +89,18 @@ export class Organization {
   cities: Set<string>
 
   // set with complex type -> L(ist)
-  @TypedSet(Birthday)
+  @CollectionProperty({ itemType: Birthday })
   birthdays: Set<Birthday>
 
-  // set with simple type -> sorted -> L(ist)
-  @SortedSet()
+  // set with simple type but sorted -> L(ist)
+  @CollectionProperty({ sorted: true })
   awards: Set<string>
 
-  // set with complex type -> sorted -> L(ist)
-  @SortedSet(OrganizationEvent)
+  // set with complex type + sorted -> L(ist)
+  @CollectionProperty({ sorted: true, itemType: OrganizationEvent })
   events: Set<OrganizationEvent>
 
-  @TypedSet()
+  @CollectionProperty()
   emptySet: Set<string> = new Set()
 
   // tslint:disable-next-line:no-empty

--- a/test/models/product.model.ts
+++ b/test/models/product.model.ts
@@ -1,10 +1,11 @@
+import { CollectionProperty } from '../../src/decorator/impl/collection/collection-property.decorator'
 // tslint:disable:max-classes-per-file
-import { Model, Property, SortedSet, TypedArray } from '../../src/dynamo-easy'
+import { Model, Property } from '../../src/dynamo-easy'
 import { NestedComplexModel } from './nested-complex.model'
 
 @Model()
 export class ProductNested {
-  @SortedSet()
+  @CollectionProperty({ sorted: true })
   collection: Set<string>
 
   counter = 0
@@ -22,7 +23,7 @@ export class Product {
   @Property()
   nestedValue: NestedComplexModel
 
-  @TypedArray(ProductNested)
+  @CollectionProperty({ itemType: ProductNested })
   list: ProductNested[]
 
   constructor() {

--- a/test/models/real-world/form-id.model.ts
+++ b/test/models/real-world/form-id.model.ts
@@ -29,7 +29,7 @@ export class FormId {
 
   type: FormType
   // if there are multiple forms for one formType the formId must have an additional postfix to be unique
-  postfix: string | undefined | null
+  postfix: string | null
   counter: number
   year: number
 
@@ -76,7 +76,7 @@ export class FormId {
     )
   }
 
-  constructor(type: FormType, counter: number, year: number, postfix?: string | null) {
+  constructor(type: FormType, counter: number, year: number, postfix: string | null = null) {
     this.type = type
     this.postfix = postfix
     this.year = year
@@ -84,7 +84,7 @@ export class FormId {
   }
 }
 
-export const FormIdMapper: MapperForType<FormId, StringAttribute> = {
+export const formIdMapper: MapperForType<FormId, StringAttribute> = {
   fromDb: (attributeValue: StringAttribute) => FormId.parse(attributeValue.S),
   toDb: (propertyValue: FormId) => ({ S: FormId.unparse(propertyValue) }),
 }
@@ -112,4 +112,9 @@ function formIdsToDb(propertyValue: FormId[] | FormId): AttributeStringOrListVal
 export const FormIdsMapper: MapperForType<FormId[] | FormId, AttributeStringOrListValue> = {
   fromDb: formIdsFromDb,
   toDb: formIdsToDb,
+}
+
+export const formIdsMapper: MapperForType<FormId[], ListAttribute> = {
+  fromDb: attributeValue => attributeValue.L.map(formIdDb => FormId.parse((<StringAttribute>formIdDb).S)),
+  toDb: propertyValue => ({ L: propertyValue.map(a => ({ S: FormId.unparse(a) })) }),
 }

--- a/test/models/real-world/form.model.ts
+++ b/test/models/real-world/form.model.ts
@@ -1,8 +1,9 @@
-import { Model, SortedSet } from '../../../src/dynamo-easy'
+import { CollectionProperty } from '../../../src/decorator/impl/collection/collection-property.decorator'
+import { Model } from '../../../src/dynamo-easy'
 import { BaseForm } from './base-form.model'
 
 @Model({ tableName: 'forms' })
 export class Form extends BaseForm {
-  @SortedSet()
+  @CollectionProperty({ sorted: true })
   types: number[]
 }

--- a/test/models/real-world/order-id.model.ts
+++ b/test/models/real-world/order-id.model.ts
@@ -27,7 +27,7 @@ export class OrderId {
   }
 }
 
-export const OrderIdMapper: MapperForType<OrderId, StringAttribute> = {
+export const orderIdMapper: MapperForType<OrderId, StringAttribute> = {
   fromDb: (attributeValue: StringAttribute) => OrderId.parse(attributeValue.S),
   toDb: (propertyValue: OrderId) => ({ S: OrderId.unparse(propertyValue) }),
 }

--- a/test/models/real-world/order.model.ts
+++ b/test/models/real-world/order.model.ts
@@ -1,22 +1,23 @@
 // tslint:disable:max-classes-per-file
 
+import { CollectionProperty } from '../../../src/decorator/impl/collection/collection-property.decorator'
 import {
-  CustomMapper,
   DateProperty,
   GSIPartitionKey,
   GSISortKey,
   Model,
   PartitionKey,
+  Property,
   Transient,
 } from '../../../src/dynamo-easy'
-import { FormId, FormIdsMapper } from './form-id.model'
+import { FormId, formIdMapper } from './form-id.model'
 import { FormType } from './form-type.enum'
-import { OrderId, OrderIdMapper } from './order-id.model'
+import { OrderId, orderIdMapper } from './order-id.model'
 
 @Model()
 export class BaseOrder {
   @PartitionKey()
-  @CustomMapper(OrderIdMapper)
+  @Property({ mapper: orderIdMapper })
   id: OrderId
 
   @GSIPartitionKey('order_product_id_creation_date')
@@ -26,7 +27,7 @@ export class BaseOrder {
   @DateProperty()
   creationDate: Date
 
-  @CustomMapper(FormIdsMapper)
+  @CollectionProperty({ sorted: true, itemMapper: formIdMapper }) // mapped to list, since sorted
   formIds: FormId[]
 
   // internal use for UI only, should not be persisted

--- a/test/models/update.model.ts
+++ b/test/models/update.model.ts
@@ -1,4 +1,5 @@
-import { DateProperty, Model, PartitionKey, Property, SortedSet } from '../../src/dynamo-easy'
+import { CollectionProperty } from '../../src/decorator/impl/collection/collection-property.decorator'
+import { DateProperty, Model, PartitionKey, Property } from '../../src/dynamo-easy'
 
 // tslint:disable-next-line:max-classes-per-file
 @Model()
@@ -36,12 +37,12 @@ export class UpdateModel {
   // maps to L(ist)
   addresses: Address[]
 
-  @SortedSet()
+  @CollectionProperty({ sorted: true })
   numberValues: number[]
 
   // maps to M(ap)
   info: Info
 
   // maps to S(tring)S(et)
-  topics: string[]
+  topics: Set<string>
 }


### PR DESCRIPTION
BREAKING CHANGE
some mappings will no longer work due to missing information for a correct parsing
without decorator, collections are consistently mapped as follows:
- `Array<any>`  <-->  [L]ist
- `Set<number|string|Binary>`   <-->  [(N|S|B)S]et

`Set<ComplextType>` --> is no longer mapped to [L]ist, only possible with decorator

closes #158 