### PR TITLE
feat(dynamo-store): use provided DynamoDB instance if any

### DIFF
--- a/src/dynamo/dynamo-db-wrapper.spec.ts
+++ b/src/dynamo/dynamo-db-wrapper.spec.ts
@@ -1,7 +1,7 @@
 // tslint:disable:no-empty
 // tslint:disable:no-unnecessary-callback-wrapper
 
-import { Config, Credentials } from 'aws-sdk/global'
+import * as DynamoDB from 'aws-sdk/clients/dynamodb'
 import { resetDynamoEasyConfig } from '../../test/helper/resetDynamoEasyConfig.function'
 import { updateDynamoEasyConfig } from '../config/update-config.function'
 import { DynamoDbWrapper } from './dynamo-db-wrapper'
@@ -130,10 +130,12 @@ describe('dynamo rx', () => {
     expect(makeRequest.calls.mostRecent().args[0]).toEqual({ ok: true })
   })
 
-  it('should update the credentials', () => {
-    const dynamoDBWrapper = new DynamoDbWrapper()
-    const credentials = new Credentials({ secretAccessKey: '', sessionToken: '', accessKeyId: '' })
-    dynamoDBWrapper.updateAwsConfigCredentials(new Config({ credentials }))
-    expect(dynamoDBWrapper.dynamoDB.config.credentials).toBe(credentials)
+  it('should use given dynamoDB client', () => {
+    const dynamoDB = new DynamoDB()
+    const dynamoDBWrapper = new DynamoDbWrapper(dynamoDB)
+    expect(dynamoDBWrapper.dynamoDB).toBe(dynamoDB)
+
+    const dynamoDBWrapper2 = new DynamoDbWrapper()
+    expect(dynamoDBWrapper2.dynamoDB).not.toBe(dynamoDB)
   })
 })

--- a/src/dynamo/dynamo-db-wrapper.ts
+++ b/src/dynamo/dynamo-db-wrapper.ts
@@ -2,7 +2,6 @@
  * @module dynamo-easy
  */
 import * as DynamoDB from 'aws-sdk/clients/dynamodb'
-import { Config } from 'aws-sdk/global'
 import { dynamoEasyConfig } from '../config/dynamo-easy-config'
 
 /**
@@ -13,13 +12,9 @@ import { dynamoEasyConfig } from '../config/dynamo-easy-config'
 export class DynamoDbWrapper {
   readonly dynamoDB: DynamoDB
 
-  constructor() {
+  constructor(dynamoDB?: DynamoDB) {
     // create the actual dynamoDB client
-    this.dynamoDB = new DynamoDB()
-  }
-
-  updateAwsConfigCredentials(newConfig: Config): void {
-    this.dynamoDB.config.update({ credentials: newConfig.credentials })
+    this.dynamoDB = dynamoDB || new DynamoDB()
   }
 
   /*

--- a/src/dynamo/dynamo-store.spec.ts
+++ b/src/dynamo/dynamo-store.spec.ts
@@ -1,6 +1,7 @@
 // tslint:disable:max-classes-per-file
 // tslint:disable:no-unnecessary-class
 // tslint:disable:no-unused-expression
+import * as DynamoDB from 'aws-sdk/clients/dynamodb'
 import { resetDynamoEasyConfig } from '../../test/helper/resetDynamoEasyConfig.function'
 import { SimpleWithPartitionKeyModel } from '../../test/models'
 import { updateDynamoEasyConfig } from '../config/update-config.function'
@@ -94,5 +95,14 @@ describe('dynamo store', () => {
   describe('allow to get dynamoDB instance', () => {
     const store = new DynamoStore(SimpleWithPartitionKeyModel)
     expect(store.dynamoDB).toBeDefined()
+  })
+
+  describe('use provided dynamoDB instance', () => {
+    const dynamoDB = new DynamoDB()
+    const store = new DynamoStore(SimpleWithPartitionKeyModel, dynamoDB)
+    expect(store.dynamoDB).toBe(dynamoDB)
+
+    const store2 = new DynamoStore(SimpleWithPartitionKeyModel)
+    expect(store2.dynamoDB).not.toBe(dynamoDB)
   })
 })

--- a/src/dynamo/dynamo-store.ts
+++ b/src/dynamo/dynamo-store.ts
@@ -30,9 +30,9 @@ export class DynamoStore<T> {
   private readonly logger: Logger
   private readonly dynamoDBWrapper: DynamoDbWrapper
 
-  constructor(private modelClazz: ModelConstructor<T>) {
+  constructor(private modelClazz: ModelConstructor<T>, dynamoDB?: DynamoDB) {
     this.logger = createLogger('dynamo.DynamoStore', modelClazz)
-    this.dynamoDBWrapper = new DynamoDbWrapper()
+    this.dynamoDBWrapper = new DynamoDbWrapper(dynamoDB)
     this.tableName = getTableName(modelClazz)
     this.logger.debug('instance created')
   }


### PR DESCRIPTION
- provide possibility to provide a DynamoDB client which will be used by the dynamo store
- also remove unnecessary updateAwsConfigCredentials on DynamoDbWrapper, the config can always be updated using the underlying dynamoDB client