### PR TITLE
feat(multi-model-requests): possibility to provide DynamoDB instance

### DIFF
--- a/src/dynamo/batchget/batch-get.request.spec.ts
+++ b/src/dynamo/batchget/batch-get.request.spec.ts
@@ -10,6 +10,17 @@ import { BatchGetRequest } from './batch-get.request'
 describe('batch get', () => {
   let request: BatchGetRequest
 
+  describe('constructor', () => {
+    it('use provided DynamoDB instance', () => {
+      const dynamoDB = new DynamoDB()
+      const batchGetRequest = new BatchGetRequest(dynamoDB)
+      expect(batchGetRequest.dynamoDB).toBe(dynamoDB)
+
+      const batchGetRequest2 = new BatchGetRequest()
+      expect(batchGetRequest2.dynamoDB).not.toBe(dynamoDB)
+    })
+  })
+
   describe('params', () => {
     beforeEach(() => (request = new BatchGetRequest()))
 

--- a/src/dynamo/batchget/batch-get.request.ts
+++ b/src/dynamo/batchget/batch-get.request.ts
@@ -18,13 +18,17 @@ import { BatchGetResponse } from './batch-get.response'
  * Request class for the BatchGetItem operation. Read multiple items from one or more tables.
  */
 export class BatchGetRequest {
+  get dynamoDB(): DynamoDB {
+    return this.dynamoDBWrapper.dynamoDB
+  }
+
   readonly params: DynamoDB.BatchGetItemInput
   private readonly dynamoDBWrapper: DynamoDbWrapper
   private readonly tables: Map<string, ModelConstructor<any>> = new Map()
   private itemCounter = 0
 
-  constructor() {
-    this.dynamoDBWrapper = new DynamoDbWrapper()
+  constructor(dynamoDB?: DynamoDB) {
+    this.dynamoDBWrapper = new DynamoDbWrapper(dynamoDB)
     this.params = {
       RequestItems: {},
     }

--- a/src/dynamo/batchwrite/batch-write.request.spec.ts
+++ b/src/dynamo/batchwrite/batch-write.request.spec.ts
@@ -1,3 +1,4 @@
+import * as DynamoDB from 'aws-sdk/clients/dynamodb'
 import { ComplexModel, SimpleWithPartitionKeyModel } from '../../../test/models'
 import { getTableName } from '../get-table-name.function'
 import { BatchWriteRequest } from './batch-write.request'
@@ -10,6 +11,15 @@ describe('batchWriteRequest', () => {
       req = new BatchWriteRequest()
       expect(req.params.RequestItems).toBeDefined()
       expect(req.params.RequestItems).toEqual({})
+    })
+
+    describe('use provided DynamoDB instance', () => {
+      const dynamoDB = new DynamoDB()
+      const batchWriteRequest = new BatchWriteRequest(dynamoDB)
+      expect(batchWriteRequest.dynamoDB).toBe(dynamoDB)
+
+      const batchWriteRequest2 = new BatchWriteRequest()
+      expect(batchWriteRequest2.dynamoDB).not.toBe(dynamoDB)
     })
   })
 

--- a/src/dynamo/batchwrite/batch-write.request.ts
+++ b/src/dynamo/batchwrite/batch-write.request.ts
@@ -14,12 +14,16 @@ import { BATCH_WRITE_DEFAULT_TIME_SLOT, BATCH_WRITE_MAX_REQUEST_ITEM_COUNT } fro
  * Request class for the BatchWriteItem operation. Put or delete multiple items in one or more table.
  */
 export class BatchWriteRequest {
+  get dynamoDB(): DynamoDB {
+    return this.dynamoDBWrapper.dynamoDB
+  }
+
   readonly params: DynamoDB.BatchWriteItemInput
   private readonly dynamoDBWrapper: DynamoDbWrapper
   private itemCount = 0
 
-  constructor() {
-    this.dynamoDBWrapper = new DynamoDbWrapper()
+  constructor(dynamoDB? : DynamoDB) {
+    this.dynamoDBWrapper = new DynamoDbWrapper(dynamoDB)
     this.params = {
       RequestItems: {},
     }

--- a/src/dynamo/transactget/transact-get.request.spec.ts
+++ b/src/dynamo/transactget/transact-get.request.spec.ts
@@ -18,6 +18,15 @@ describe('TransactGetRequest', () => {
       expect(req.params.TransactItems).toBeDefined()
       expect(req.params.TransactItems.length).toBe(0)
     })
+
+    it('use provided DynamoDB instance', () => {
+      const dynamoDB = new DynamoDB()
+      const transactGetRequest = new TransactGetRequest(dynamoDB)
+      expect(transactGetRequest.dynamoDB).toBe(dynamoDB)
+
+      const transactGetRequest2 = new TransactGetRequest()
+      expect(transactGetRequest2.dynamoDB).not.toBe(dynamoDB)
+    })
   })
 
   describe('returnConsumedCapacity', () => {

--- a/src/dynamo/transactget/transact-get.request.ts
+++ b/src/dynamo/transactget/transact-get.request.ts
@@ -19,12 +19,16 @@ const MAX_REQUEST_ITEM_COUNT = 10
  * Request class for the TransactGetItems operation. Read up to 10 items from one or more tables in a transaction.
  */
 export class TransactGetRequest {
+  get dynamoDB(): DynamoDB {
+    return this.dynamoDBWrapper.dynamoDB
+  }
+
   readonly params: DynamoDB.TransactGetItemsInput
   private readonly dynamoDBWrapper: DynamoDbWrapper
   private readonly tables: Array<ModelConstructor<any>> = []
 
-  constructor() {
-    this.dynamoDBWrapper = new DynamoDbWrapper()
+  constructor(dynamoDB?: DynamoDB) {
+    this.dynamoDBWrapper = new DynamoDbWrapper(dynamoDB)
     this.params = {
       TransactItems: [],
     }

--- a/src/dynamo/transactwrite/transact-write.request.spec.ts
+++ b/src/dynamo/transactwrite/transact-write.request.spec.ts
@@ -1,4 +1,5 @@
 // tslint:disable:no-non-null-assertion
+import * as DynamoDB from 'aws-sdk/clients/dynamodb'
 import { SimpleWithPartitionKeyModel } from '../../../test/models'
 import { attribute } from '../expression/logical-operator/attribute.function'
 import { update } from '../expression/logical-operator/update.function'
@@ -21,6 +22,15 @@ describe('TransactWriteRequest', () => {
       expect(req.params).toEqual({
         TransactItems: [],
       })
+    })
+
+    it('use provided DynamoDB instance', () => {
+      const dynamoDB = new DynamoDB()
+      const transactWriteRequest = new TransactWriteRequest(dynamoDB)
+      expect(transactWriteRequest.dynamoDB).toBe(dynamoDB)
+
+      const transactWriteRequest2 = new TransactWriteRequest()
+      expect(transactWriteRequest2.dynamoDB).not.toBe(dynamoDB)
     })
   })
 

--- a/src/dynamo/transactwrite/transact-write.request.ts
+++ b/src/dynamo/transactwrite/transact-write.request.ts
@@ -9,11 +9,15 @@ import { TransactOperation } from './transact-operation.type'
  * Request class for the TransactWriteItems operation. Write up to 10 items to one or many tables in a transaction.
  */
 export class TransactWriteRequest {
+  get dynamoDB(): DynamoDB {
+    return this.dynamoDBWrapper.dynamoDB
+  }
+
   readonly params: DynamoDB.TransactWriteItemsInput
   private readonly dynamoDBWrapper: DynamoDbWrapper
 
-  constructor() {
-    this.dynamoDBWrapper = new DynamoDbWrapper()
+  constructor(dynamoDB?: DynamoDB) {
+    this.dynamoDBWrapper = new DynamoDbWrapper(dynamoDB)
     this.params = {
       TransactItems: [],
     }


### PR DESCRIPTION
When implementing https://github.com/shiftcode/dynamo-easy/issues/194 the multi-model requests were not updated, this change adds the possibility to provide a custom DynamoDB instance to those requests too. And also a getter for the dynamoDB instance for easier access.

Make sure to merge [gitbook draft](https://shiftcode.gitbook.io/dynamo-easy/~/drafts/-L_TE1E84QTSgvGgLIBL/primary/)