### PR TITLE
fix(npm-package): don't publish docs to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "license": "MIT",
   "author": "Michael Wittwer <michael.wittwer@shiftcode.ch>",
   "files": [
-    "dist"
+    "dist",
+    "!dist/docs"
   ],
   "main": "./dist/dynamo-easy.js",
   "module": "./dist/_esm5/dynamo-easy.js",


### PR DESCRIPTION
remove dist/docs folder from published npm package

closes #202 