### PR TITLE
feat(add-getter-support): map es6 class getters

### DIFF
--- a/src/mapper/mapper.spec.ts
+++ b/src/mapper/mapper.spec.ts
@@ -460,7 +460,7 @@ describe('Mapper', () => {
 
         describe('creates correct attribute map', () => {
           it('all properties are mapped', () => {
-            expect(Object.keys(organizationAttrMap).length).toBe(13)
+            expect(Object.keys(organizationAttrMap).length).toBe(14)
           })
 
           it('id', () => {
@@ -651,6 +651,10 @@ describe('Mapper', () => {
           it('emptySet', () => {
             expect(organizationAttrMap.emptySet).toBeUndefined()
             // expect(organizationAttrMap.emptySet).toEqual({ NULL: true })
+          })
+
+          it('getter', () => {
+            expect(organizationAttrMap.getter).toEqual({ S: 'myId:shiftcode GmbH' })
           })
         })
       })

--- a/src/mapper/mapper.ts
+++ b/src/mapper/mapper.ts
@@ -352,7 +352,7 @@ export function getPropertyValue(item: any, propertyKey: PropertyKey): any {
  * @hidden
  */
 function getES6ClassProperties<T>(item: T) {
-  const jsonObj: any = Object.assign({}, item)
+  const jsonObj: any = {...(item as any)}
   const proto = Object.getPrototypeOf(item)
   for (const key of Object.getOwnPropertyNames(proto)) {
     const desc = Object.getOwnPropertyDescriptor(proto, key)

--- a/src/mapper/mapper.ts
+++ b/src/mapper/mapper.ts
@@ -46,6 +46,8 @@ export function toDb<T>(item: T, modelConstructor?: ModelConstructor<T>): Attrib
     }
   }
 
+  item = getES6ClassProperties(item)
+
   const propertyNames = <Array<keyof T>>Object.getOwnPropertyNames(item) || []
   propertyNames.forEach(propertyKey => {
     /*
@@ -344,4 +346,20 @@ export function getPropertyValue(item: any, propertyKey: PropertyKey): any {
       `there is no property descriptor for item ${JSON.stringify(item)} and property key ${<string>propertyKey}`,
     )
   }
+}
+
+/**
+ * @hidden
+ */
+function getES6ClassProperties<T>(item: T) {
+  const jsonObj: any = Object.assign({}, item)
+  const proto = Object.getPrototypeOf(item)
+  for (const key of Object.getOwnPropertyNames(proto)) {
+    const desc = Object.getOwnPropertyDescriptor(proto, key)
+    const hasGetter = desc && typeof desc.get === 'function'
+    if (hasGetter) {
+      jsonObj[key] = (item as any)[key]
+    }
+  }
+  return jsonObj
 }

--- a/test/models/organization.model.ts
+++ b/test/models/organization.model.ts
@@ -110,6 +110,10 @@ export class Organization {
   @CollectionProperty()
   emptySet: Set<string> = new Set()
 
+  get getter(): string {
+    return `${this.id}:${this.name}`
+  }
+
   // tslint:disable-next-line:no-empty
   constructor() {}
 }


### PR DESCRIPTION
### Summary
This Pull Request introduces the ability to map ES6 class getters just like other properties.  

### Motivation
Mapping from `get`ters allows for having dynamically composed values out of the model class.
For us, it is particularly useful for composite sort key cases as described [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-sort-keys.html).  
Allow for having something in the lines of:
```typescript
@Model()
class Person {
  @PartitionKeyUUID()
  id: string;
  country: string;
  region: string;
  city: string;

  @SortKey()
  get locationSortKey() {
    return `${this.country}:${this.region}:${this.city}`
  }
}
```
I was able to get it going with `@GSISortKey()` as well - having an easy way to compose key for secondary indexes seems powerful.  

### How?
Simply by adding those `get`ters from the prototype class to the mapped fields array.  
A simple unit test was added as well.  
