### PR TITLE
feat(empty-strings): drop empty string strictness to allow new empty string feature

### DIFF
--- a/src/mapper/for-type/string.mapper.spec.ts
+++ b/src/mapper/for-type/string.mapper.spec.ts
@@ -9,7 +9,7 @@ describe('string mapper', () => {
 
     it('should work (empty string)', () => {
       const attributeValue = StringMapper.toDb('')
-      expect(attributeValue).toBe(null)
+      expect(attributeValue).toStrictEqual({ S: '' })
     })
 
     it('should work (null)', () => {
@@ -27,6 +27,10 @@ describe('string mapper', () => {
     it('should work', () => {
       const stringValue = StringMapper.fromDb({ S: 'myStringValue' })
       expect(stringValue).toBe('myStringValue')
+    })
+    it('should allow empty string values', () => {
+      const stringValue = StringMapper.fromDb({ S: '' })
+      expect(stringValue).toBe('')
     })
     it('should throw if not a string attribute', () => {
       expect(() => StringMapper.fromDb(<any>{ N: '8' })).toThrow()

--- a/src/mapper/for-type/string.mapper.ts
+++ b/src/mapper/for-type/string.mapper.ts
@@ -5,7 +5,7 @@ import { StringAttribute } from '../type/attribute.type'
 import { MapperForType } from './base.mapper'
 
 function stringFromDb(attributeValue: StringAttribute): string {
-  if (attributeValue.S) {
+  if (attributeValue.S || attributeValue.S === '') {
     return attributeValue.S
   } else {
     throw new Error(`there is no S(tring) value defined on given attribute value: ${JSON.stringify(attributeValue)}`)
@@ -13,8 +13,8 @@ function stringFromDb(attributeValue: StringAttribute): string {
 }
 
 function stringToDb(modelValue: string): StringAttribute | null {
-  // an empty string is not a valid value for string attribute
-  if (modelValue === '' || modelValue === null || modelValue === undefined) {
+  // an empty string is valid for a string attribute
+  if (modelValue === null || modelValue === undefined) {
     return null
   } else {
     return { S: modelValue }

--- a/src/mapper/mapper.spec.ts
+++ b/src/mapper/mapper.spec.ts
@@ -67,7 +67,7 @@ describe('Mapper', () => {
 
       it('string (empty)', () => {
         const attrValue = <StringAttribute>toDbOne('')!
-        expect(attrValue).toBeNull()
+        expect(attrValue.S).toStrictEqual('')
       })
 
       it('number', () => {
@@ -801,7 +801,7 @@ describe('Mapper', () => {
           // OK
           id: 'myId',
 
-          // x -> empty strings are not valid
+          // x -> empty strings are valid
           name: '',
 
           // x -> empty set is not valid
@@ -824,7 +824,8 @@ describe('Mapper', () => {
         expect(toDbValue.id).toBeDefined()
         expect(keyOf(toDbValue.id)).toBe('S')
 
-        expect(toDbValue.name).toBeUndefined()
+        expect(toDbValue.name).toBeDefined()
+        expect(keyOf(toDbValue.name)).toBe('S')
 
         expect(toDbValue.roles).toBeUndefined()
 


### PR DESCRIPTION
## What

* String Mapper now allows empty strings

## Why

* Dynamodb has added support for empty strings, this can be vey helpful on updates where you could be looking for `deletions` and defaults.