### PR TITLE
Increase transact write items limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "tsutils": "^3.17.1",
     "typedoc": "0.14.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
-    "typescript": ">=2.9.1"
+    "typescript": ">=2.9.1 <4.0.0"
   },
   "peerDependencies": {
     "aws-sdk": "^2.401.0",

--- a/src/dynamo/transactwrite/transact-write.request.ts
+++ b/src/dynamo/transactwrite/transact-write.request.ts
@@ -6,7 +6,7 @@ import { DynamoDbWrapper } from '../dynamo-db-wrapper'
 import { TransactOperation } from './transact-operation.type'
 
 /**
- * Request class for the TransactWriteItems operation. Write up to 10 items to one or many tables in a transaction.
+ * Request class for the TransactWriteItems operation. Write up to 25 items to one or many tables in a transaction.
  */
 export class TransactWriteRequest {
   get dynamoDB(): DynamoDB {
@@ -40,7 +40,7 @@ export class TransactWriteRequest {
   }
 
   /**
-   * add up to 10 transaction operations
+   * add up to 25 transaction operations
    * create the operations with:
    * {@link TransactConditionCheck}, {@link TransactDelete}, {@link TransactPut}, {@link TransactUpdate}
    */
@@ -48,8 +48,8 @@ export class TransactWriteRequest {
     if (!writeOperations || writeOperations.length === 0) {
       throw new Error('at least one transaction operation must be added')
     }
-    if (this.params.TransactItems.length + writeOperations.length > 10) {
-      throw new Error(`Each transaction can include up to 10 unique items, including conditions.\
+    if (this.params.TransactItems.length + writeOperations.length > 25) {
+      throw new Error(`Each transaction can include up to 25 unique items, including conditions.\
        Given operations count: ${this.params.TransactItems.length + writeOperations.length}`)
     }
     this.params.TransactItems.push(...writeOperations.map((wo) => wo.transactItem))

--- a/test/models/model-with-custom-mapper-for-sort-key.model.ts
+++ b/test/models/model-with-custom-mapper-for-sort-key.model.ts
@@ -20,9 +20,9 @@ export class CustomId {
   }
 
   static unparse(customId: CustomId): string {
-    const yyyy = customId.date.getFullYear()
-    const mm = (<any>(customId.date.getMonth() + 1).toString()).padStart(2, '0')
-    const dd = (<any>customId.date.getDate().toString()).padStart(2, '0')
+    const yyyy = customId.date.getUTCFullYear()
+    const mm = (<any>(customId.date.getUTCMonth() + 1).toString()).padStart(2, '0')
+    const dd = (<any>customId.date.getUTCDate().toString()).padStart(2, '0')
     return `${yyyy}${mm}${dd}${(<any>customId.id.toString()).padStart(CustomId.MULTIPLIER_E, '0')}`
   }
 


### PR DESCRIPTION
Amazon increased the TransactWriteItem limit to 25. This update increases the Dynamo-Easy limit to match. For more info see: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html#transaction-apis-txwriteitems.